### PR TITLE
build settings removing unity editor

### DIFF
--- a/Assets/Scripts/Paredao.cs
+++ b/Assets/Scripts/Paredao.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
-using UnityEditor;
 using UnityEngine;
 
 public class Paredao : MonoBehaviour

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Runtime.CompilerServices;
 using System.Threading;
-using UnityEditorInternal;
 using UnityEngine;
 
 public class PlayerController : MonoBehaviour

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -4,5 +4,8 @@
 EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
-  m_Scenes: []
+  m_Scenes:
+  - enabled: 1
+    path: Assets/Scenes/MainScene.unity
+    guid: 0f7704efecc9edd4dbd2faa47a2841bc
   m_configObjects: {}


### PR DESCRIPTION
Removi o Unity Editor que causa o erro da extensão do editor, que não tem compilação em tempo real.